### PR TITLE
Fix innerHTML -> value

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -204,7 +204,7 @@ ${code}
                     break
             }
             var outputBox = document.getElementById("output");
-            outputBox.innerHTML = output;
+            outputBox.value = output;
             copyToClipboard("output")
         }
 


### PR DESCRIPTION
the markdown format buttons at the top of the page don't work because they are trying to set the innerHTML of a textarea