### PR TITLE
Fixed bug with offline interpreter failing to execute

### DIFF
--- a/Vyxal.py
+++ b/Vyxal.py
@@ -1715,16 +1715,18 @@ def VY_filter(fn, vector):
     }[types]()
 def VY_int(item, base=10):
     t_item = type(item)
-    if t_item not in [str, float, int]:
+    if t_item not in [str, float, int, complex]:
         ret = 0
         for element in item:
             ret = multiply(ret, base)
             ret = add(ret, element)
         return ret
-    elif t_item is not str:
-        return int(item)
-    elif t_item:
+    elif t_item is str:
         return int(item, base)
+    elif t_item is complex:
+        return numpy.real(item)
+    elif t_item:
+        return int(item)
 def VY_map(fn, vector):
     ret = []
     t_vector = VY_type(vector)

--- a/Vyxal.py
+++ b/Vyxal.py
@@ -2372,7 +2372,7 @@ if __name__ == "__main__":
     file_location = ""
     flags = ""
     inputs = []
-    header = "stack = []\nregister = 0\nprinted = False"
+    header = "stack = []\nregister = 0\nprinted = False\n"
 
     if len(sys.argv) > 1:
         file_location = sys.argv[1]


### PR DESCRIPTION
`header` didn't have a newline at the end of it, so the first line of `compiled` was being appended to the last list of `header`, giving output like:
```
aaron@localhost:~/Vyxal$ python Vyxal.py test c
stack = []
register = 0
printed = Falsestack.append(42)


Traceback (most recent call last):
  File "Vyxal.py", line 2479, in <module>
    exec(code)
  File "<string>", line 3, in <module>
NameError: name 'Falsestack' is not defined
```

Also made it so that the `I` command can cast complex number to real numbers by removing the imaginary part, similar to casting floats to ints by removing the decimal part. (These were supposed to be two separate PRs, but I accidentally made them into one.)