### PR TITLE
fixed offline integer parsing bug

### DIFF
--- a/VyParse.py
+++ b/VyParse.py
@@ -271,7 +271,7 @@ def Tokenise(source: str):
                 end = value.find(".", value.find(".") + 1)
 
                 if end > -1:
-                    value = value[:value.find(".", value.find("."))]
+                    value = value[:end]
 
                 if value.isnumeric():
                     this_token = Token(INTEGER, int(value))


### PR DESCRIPTION
Fixed bug where a number with multiple decimal points would only push the number up to the first decimal, e.g. 
```
123,          || 123       // Expected
123.456,      || 123.456   // Expected
123.456.,     || 123       // Not Expected
123.456.789,  || 123       // Not Expected
```
This bug only affects the offline interpreter, though I don't understand why.