### PR TITLE
strings and structures decided to get along

### DIFF
--- a/VyParse.py
+++ b/VyParse.py
@@ -250,9 +250,31 @@ def Tokenise(source: str):
             continue
 
         elif type(char) is list:
-            if structure != NO_STMT:
+            if structure not in [NO_STMT, INTEGER, VARIABLE_GET, VARIABLE_SET]:
                 structure_data[active_key] += char[1] + char[0] + char[1]
             else:
+                if structure == INTEGER:
+                    value = structure_data[active_key]
+                    end = value.find(".", value.find(".") + 1)
+
+                    if end > -1:
+                        value = value[:end]
+
+                    if value.isnumeric():
+                        this_token = Token(INTEGER, int(value))
+
+                    else:
+                        this_token = Token(INTEGER, float(value))
+                    tokens.append(this_token)
+                    structure_data = {}
+                    structure = NO_STMT
+                elif structure in VARIABLES:
+                    this_token = Token(structure, structure_data)
+                    tokens.append(this_token)
+                    structure_data = {}
+                    structure = NO_STMT
+                    active_key = ""
+                    default_key = ""
                 yes = ({"`": STRING_STMT,
                     "«": COMPRESSED_STRING,
                     "»": COMPRESSED_NUMBER

--- a/VyParse.py
+++ b/VyParse.py
@@ -600,8 +600,8 @@ def Tokenise(source: str):
     return tokens
 
 if __name__ == "__main__":
-    tests = ["«S⊍ǐ/µȦġk*∪±c*ɖøW₌≤₀e+₇ /)ðaðc~²⊍λġOṙŻZ⁽ɽẇ¼∴ðḂ>⁰IŻ↳Y%⁼ǐ∩\\ǔḞo⁋$∪@ø₇↑^V×Qc□„&<$↲AFðM‟[Ẏ`∵∪SĊ⟩%IHṠλ!q⟩»ꜝ∩=ẏ¼≥ȧ(ε∑²Z₁Ẇġ@Ḃ9d@3ġf₇Ṗꜝµ∞†≥¨ǐ $*∆⇩nTǎ√7Ḃ«"]
-    # "‡∆p-Ẋ1=", "‘ab", "‡∆p-Ẋ1=", "‡ab", "`\\``", "‡kAkA", "vøD", 
+    # tests = ["«S⊍ǐ/µȦġk*∪±c*ɖøW₌≤₀e+₇ /)ðaðc~²⊍λġOṙŻZ⁽ɽẇ¼∴ðḂ>⁰IŻ↳Y%⁼ǐ∩\\ǔḞo⁋$∪@ø₇↑^V×Qc□„&<$↲AFðM‟[Ẏ`∵∪SĊ⟩%IHṠλ!q⟩»ꜝ∩=ẏ¼≥ȧ(ε∑²Z₁Ẇġ@Ḃ9d@3ġf₇Ṗꜝµ∞†≥¨ǐ $*∆⇩nTǎ√7Ḃ«"]
+    tests = ["123.456`hello`789 42→x`world` ←x", "‡∆p-Ẋ1=", "‘ab", "‡∆p-Ẋ1=", "‡ab", "`\\``", "‡kAkA", "vøD"]
     for test in tests:
         print([(n[0], n[1]) for n in Tokenise(group_two_bytes(group_strings(test)))])
     input()

--- a/Vyxal.py
+++ b/Vyxal.py
@@ -1480,6 +1480,12 @@ def string_empty(item):
 def strip_non_alphabet(name):
     stripped = filter(lambda char: char in string.ascii_letters + "_", name)
     return "".join(stripped)
+def sublists(item):
+    yield []
+    length = len(item)
+    for size in range(1, length + 1):
+        for sub in range((length - size) + 1):
+            yield item[sub:sub+size]
 def substrings(item):
     for i in range(0, len(item) + 1):
         for j in range(1, len(item) + 1):

--- a/commands.py
+++ b/commands.py
@@ -285,6 +285,7 @@ list_command_dict = {
     "U": ("stack.append(nub_sieve(iterable(pop(stack))))", 1),
     "T": ("stack.append(transpose(pop(stack)))", 1),
     "D": ("stack.append(Generator(diagonals(iterable(pop(stack), list))))", 1),
+    "S": ("stack.append(Generator(sublists(iterable(pop(stack), list))))", 1),
 }
 
 misc_command_dict = {

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -558,5 +558,6 @@ cmd | inputs | out/effect
 | ÞF |   |  * every fibonacci number |
 | Þ! |   |  * every factorial |
 | ÞD | (a: list)                          |  diagonals of a - starts with main diagonal. |
+| ÞS | (a: any)                           |  sublists(a) |
 | ¨U | (a: string)                        |  GET request with url=a |
 | ¨M | (a: list, b: list, c: function)    |  map function c to every item in a who's index is in b |

--- a/docs/elements.txt
+++ b/docs/elements.txt
@@ -555,5 +555,6 @@ kṡ                                   = seconds since epoch
 ÞF                                   = * every fibonacci number
 Þ!                                   = * every factorial
 ÞD (a: list)                         = diagonals of a - starts with main diagonal.
+ÞS (a: any)                          = sublists(a)
 ¨U (a: string)                       = GET request with url=a
 ¨M (a: list, b: list, c: function)   = map function c to every item in a who's index is in b


### PR DESCRIPTION
There was a parsing bug where a string at the end of an integer or a variable name would be parsed as part of it, e.g.
```
123.456`hello`789
```
This program tries to convert ```123.456`hello`789``` to a float, which errors. 

```
42→x`world`
```
This program tries to assign `42` to a variable named ``` x`world` ``` which also errors.

Now, the first program pushes `123.456`, `hello`, and `789` to the stack. The second program assigns `42` to a variable named `x` and pushes `world` to the stack.