### PR TITLE
`uneval` is now `uneval` and can be `eval`ed to un`uneval`

### DIFF
--- a/Vyxal.py
+++ b/Vyxal.py
@@ -1680,6 +1680,12 @@ def two_power(item):
         return out
     else:
         return vectorise(two_power, item)
+def uneval(item):
+    item = [char for char in item]
+    indexes = [i for i, ltr in enumerate(item) if ltr in ["\\", "`"]][::-1]
+    for i in indexes:
+        item.insert(i, "\\")
+    return "`" + "".join(item) + "`"
 def uninterleave(item):
     left, right = [], []
     for i in range(len(item)):

--- a/commands.py
+++ b/commands.py
@@ -94,7 +94,7 @@ command_dict = {
     "n": ("stack.append(context_values[context_level % len(context_values)])", 0),
     "o": ("needle, haystack = pop(stack, 2); stack.append(remove(haystack, needle))", 2),
     "p": ("rhs, lhs = pop(stack, 2); stack.append(join(rhs, lhs))", 2),
-    "q": ("stack.append('`' + VY_str(pop(stack)) + '`')", 1),
+    "q": ("stack.append(uneval(VY_str(pop(stack))))", 1),
     "r": ("rhs, lhs = pop(stack, 2); stack.append(orderless_range(lhs, rhs))", 2),
     "s": ("stack.append(VY_sorted(pop(stack)))", 1),
     "t": ("stack.append(iterable(pop(stack))[-1])", 1),


### PR DESCRIPTION
Fixed #64

Test program:
```
`Hello, World!`qĖ,
389qĖ,
4.3qĖ,
`\\t\\`qĖ,
`\\\`\`\\\\`qĖ,
`\
`qĖ,
`--------`qĖ,
`--------`,
`Hello, World!`,
389,
4.3,
`\\t\\`,
`\\\`\`\\\\`,
`\
`,
```