### PR TITLE
Fixed ₅ for strings, ₂₃₅ work for lists now 

### DIFF
--- a/Vyxal.py
+++ b/Vyxal.py
@@ -535,9 +535,16 @@ def combinations_replace_generate(lhs, rhs):
                 curr = fn([curr])[-1]
         return Generator(gen())
 def const_divisibility(item, n, string_overload):
+    def int_if_not_tuple():
+        a = string_overload(item)
+        if type(a) is tuple: 
+            return a
+        else:
+            return int(a)
     return {
         Number: lambda: int(item % n == 0),
-        str: lambda: int(string_overload(item))
+        str: int_if_not_tuple,
+        list: int_if_not_tuple
     }.get(VY_type(item), lambda: vectorise(const_divisibility, item, n, string_overload))()
 def counts(vector):
     ret = []


### PR DESCRIPTION
`₅` was broken for strings, throwing an error because it couldn't serialise a tuple to an int. This has been fixed.

Addtionally, `₂`, `₃`, and `₅`  (respectively `len(a) % 2 == 0`, `len(a) == 1`, and `a, len(a)`)  work for lists now, with exactly the same functionality as on strings. 