### PR TITLE
Define types in join_on

### DIFF
--- a/Vyxal.py
+++ b/Vyxal.py
@@ -1087,6 +1087,7 @@ def join(lhs, rhs):
         (Generator, Generator): lambda: lhs._dereference() + rhs._dereference()
     }[types]()
 def join_on(vector, item):
+    types = VY_type(vector), VY_type(item)
     return {
         (Number, Number): lambda: VY_eval(str(item).join(str(vector))),
         (Number, str): lambda: item.join(str(vector)),


### PR DESCRIPTION
All hail flake8, which pointed out that types wasn't defined on line 1094 (now line 1095).